### PR TITLE
Fix top and bottom spacing. Issue #38

### DIFF
--- a/SJSegmentedScrollView/Classes/SJUtil.swift
+++ b/SJSegmentedScrollView/Classes/SJUtil.swift
@@ -42,7 +42,9 @@ class SJUtil {
 
 			if navigationController?.isNavigationBarHidden == false {
 				topSpacing = UIApplication.shared.statusBarFrame.height
-				topSpacing += (navigationController?.navigationBar.bounds.height)!
+                if !(navigationController?.navigationBar.isOpaque)! {
+                    topSpacing += (navigationController?.navigationBar.bounds.height)!
+                }
 			}
 		}
 		
@@ -59,7 +61,7 @@ class SJUtil {
         var bottomSpacing: CGFloat = 0.0
 
         if let tabBarController = viewController.tabBarController {
-            if !tabBarController.tabBar.isHidden {
+            if !tabBarController.tabBar.isHidden && !tabBarController.tabBar.isOpaque {
                 bottomSpacing += tabBarController.tabBar.bounds.size.height
             }
         }


### PR DESCRIPTION
Fix issue number 38 that didn’t take into consideration if the
navigationBar or the tabBar are opaque, when calculating the top and
bottom spacing respectively.